### PR TITLE
Add category to sources to be scraped

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -3,8 +3,8 @@
 
 require 'wikidata/fetcher'
 
-en_names = EveryPolitician::Wikidata.morph_wikinames(source: 'tmtmtmtm/malaysian_parliament-wp', column: 'wikipedia__en')
+en_names = EveryPolitician::Wikidata.morph_wikinames(source: 'tmtmtmtm/malaysian_parliament-wp', column: 'wikipedia__en') |
+           WikiData::Category.new( 'Category:Members of the Dewan Rakyat', 'en').member_titles
 ms_names = WikiData::Category.new( 'Kategori:Ahli Parlimen Malaysia 1959', 'ms').member_titles
 
 EveryPolitician::Wikidata.scrape_wikidata(names: { en: en_names, ms: ms_names })
-


### PR DESCRIPTION
Some members are not present in members scraper data as they have been removed from source list.
To cover missing data, we merge the data from another source.
Category:Members of the Dewan Rakyat is a more complete source.
